### PR TITLE
fix/resolve-multiple-keyword-values-error

### DIFF
--- a/django_scoped_permissions/graphql.py
+++ b/django_scoped_permissions/graphql.py
@@ -58,7 +58,9 @@ class ScopedDjangoNode(DjangoObjectType):
         _meta.node_permissions = node_permissions
         _meta.field_permissions = field_permissions
         _meta.verb = verb
-        interfaces = options.get("interfaces", ()) + (Node,)
+
+        # Remove interfaces from options and add Node, ensuring only one interfaces gets added
+        interfaces = options.pop("interfaces", ()) + (Node,)
 
         # Great, the class is set up. Now let's add permission guards.
         field_permissions = field_permissions or {}


### PR DESCRIPTION
- **fix(ScopedDjangoNode): Pop interfaces out of options objects before extending**

This removes an error in the`__init_subclass_with_meta__` call which get a duplicate interfaces keyword 
argument passed to it if an interface is implemented by inheriting object.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of interfaces in the permissions system to prevent unintended multiple interface inclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->